### PR TITLE
FIX: Invalid addresses passing as valid.

### DIFF
--- a/coinaddrvalidator/validation.py
+++ b/coinaddrvalidator/validation.py
@@ -717,7 +717,7 @@ def validate(currency_name, address):
             name='',
             ticker=currency_name,
             address=bytes(address, 'utf-8'),
-            valid=True,
+            valid=False,
             network='',
             address_type='address',
             is_extended=False

--- a/coinaddrvalidator/validation.py
+++ b/coinaddrvalidator/validation.py
@@ -705,7 +705,7 @@ def validate(currency_name, address):
       ...              valid=True, network='main')
 
     """
-
+    currency_name = currency_name.lower()
     tickers = [currency.Currencies.instances[curr].ticker for curr in currency.Currencies.instances]
     currencies = [currency.Currencies.instances[curr].name for curr in currency.Currencies.instances]
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -5,7 +5,7 @@ from coinaddrvalidator.interfaces import (
     )
 from coinaddrvalidator.validation import (
     Validators, ValidatorBase, ValidationRequest, ValidationResult,
-    Base58CheckValidator, EthereumValidator
+    Base58CheckValidator, EthereumValidator, validate
     )
 
 
@@ -26,6 +26,10 @@ class TestValidation(unittest.TestCase):
     def test_invalid_as_default(self):
         result = validate("BTC", b"not_an_address")
         self.assertFalse(result.valid)
+
+    def test_uppercase_symbol(self):
+        result = validate("BTC", "12nMGd6bzC8UpyWjd9HeZESZheZ8arttAb")
+        self.assertTrue(result.valid)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -23,6 +23,9 @@ class TestValidation(unittest.TestCase):
         self.assertTrue(
             IValidationResult.implementedBy(ValidationResult))
 
+    def test_invalid_as_default(self):
+        result = validate("BTC", b"not_an_address")
+        self.assertFalse(result.valid)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
### Summary

This PR fixes an issue where invalid addresses would be returned as being valid.

### Explanation

Until now `ValidationResult` defaulted to `valid=True.` In other words, if the library didn't have a matching `currency_name`, it would just tell you the address is valid regardless of the actual address value. This problem is compounded by the fact that until now the library was only matching lowercase `currency_name` values.

### Examples

#### Before:
```python
# Uppercase `currency_name` always returns `valid=True`
>>> coinaddrvalidator.validate("BTC", b"clearly_not_an_address")
ValidationResult(name='', ticker='BTC', address=b'clearly_not_an_address', valid=True, network='', is_extended=False, address_type='address')

# Lowercase `currency_name` is handled correctly
>>> coinaddrvalidator.validate("btc", b"12nMGd6bzC8UpyWjd9HeZESZheZ8arttAb")
ValidationResult(name='bitcoin', ticker='btc', address=b'12nMGd6bzC8UpyWjd9HeZESZheZ8arttAb', valid=True, network='main', is_extended=False, address_type='address')
```

#### After:
```python
# Uppercase `currency_name` always returns `valid=True`
>>> coinaddrvalidator.validate("BTC", b"clearly_not_an_address")
ValidationResult(name='bitcoin', ticker='btc', address=b'clearly_not_an_address', valid=False, network='', is_extended=False, address_type='address')

# Lowercase `currency_name` is handled correctly
>>> coinaddrvalidator.validate("BTC", b"12nMGd6bzC8UpyWjd9HeZESZheZ8arttAb")
ValidationResult(name='bitcoin', ticker='btc', address=b'12nMGd6bzC8UpyWjd9HeZESZheZ8arttAb', valid=True, network='main', is_extended=False, address_type='address')
```

### Notes

The BTC address I used in the added tests is the donation address for the [Electronic Frontier Foundation](https://www.eff.org/pages/other-ways-give-and-donor-support#BTC).
